### PR TITLE
Bump org.apache.logging.log4j:log4j-core from 2.0.2 to 2.12.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
 		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>
 			<artifactId>log4j-core</artifactId>
-			<version>2.0.2</version>
+			<version>2.12.4</version>
 		</dependency>
 		<!-- JDK7-Workaround: JDK7 does have JavaFX, but not in the regular classpath. 
 			Add the following dependency to add it. <dependency> <groupId>javafx</groupId> 


### PR DESCRIPTION
Bumps org.apache.logging.log4j:log4j-core from 2.0.2 to 2.12.4.

---
updated-dependencies:
- dependency-name: org.apache.logging.log4j:log4j-core dependency-type: direct:production ...